### PR TITLE
CSS for Course Page using .clearfix

### DIFF
--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -23,6 +23,14 @@ text-rendering: optimizeLegibility;
 font-family: 'Lato', sans-serif;
 }
 
+.clearfix {zoom: 1}
+.clearfix:after {
+    content: '.';
+    clear: both;
+    display: block;
+    height: 0;
+    visibility: hidden;
+}
 
 /*-------------------------------------*/
 /*Reusable Components*/


### PR DESCRIPTION
For #58 
The problem was someone removed the `clearfix` class from `style.css`. I was not able to find how and when it got removed, but anyways, I have corrected it now.

The padding may look less in the syllabus and resources content, but I'll correct it after some content is added.